### PR TITLE
NFCリーダーの処理を最適化

### DIFF
--- a/src/reader.py
+++ b/src/reader.py
@@ -38,9 +38,14 @@ class Reader:
                     logger.info("Retrieving serial data from Controller...")
                     sleep(0.01)
                     if not self.flag.is_set():
-                        logger.info(f"Data Received!: {self.array[1]}")
-                        # TODO: POST data to Control Server
-                        break
+                        logger.info(f"Data Received!: {self.array}")
+                        if self.array[7] is 0:
+                            logger.warning("Serial Data is invalid!")
+                            logger.warning("DATA won't send to Control Server!!")
+                            break
+                        else:
+                            # TODO: POST data to Control Server
+                            break
 
         else:
             logger.error("TAG TYPE ERROR: Tag isn't Type3Tag")

--- a/src/reader.py
+++ b/src/reader.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 import nfc
 
 from logging import getLogger
@@ -34,6 +36,7 @@ class Reader:
                 self.flag.set()
                 while True:
                     logger.info("Retrieving serial data from Controller...")
+                    sleep(0.01)
                     if not self.flag.is_set():
                         logger.info(f"Data Received!: {self.array[1]}")
                         # TODO: POST data to Control Server


### PR DESCRIPTION
## What does this PR do ? / PRの目的
NFCリーダー側の処理を最適化

## Implementations / 実装したこと
- シリアルのコントローラーからの応答を待つためにループ毎に0.01秒待つようにした f6f97aa09ab63c699c659dde74bca1d4d5dbf22b
- シリアルからのデータが不正な形式の場合に以後の処理を行わないようにした de2545b930a30e363de5e530add720834323fadf

## References / 参考資料
なし