### PR TITLE
シリアルポートのエラーハンドリング修正

### DIFF
--- a/src/controller.py
+++ b/src/controller.py
@@ -62,6 +62,7 @@ def serial_read(serial_port):
             logger.warning("Failed to get button/key data.")
             return False, []
 
-    except KeyboardInterrupt:
-        serial_port.close()
+    # エラー吐いたら問答無用でお返しします
+    except:
+        logger.error("Failed to get button/key data.")
         return False, []

--- a/src/controller.py
+++ b/src/controller.py
@@ -1,4 +1,4 @@
-import sys
+import os
 import serial
 import time
 from serial import SerialException
@@ -14,8 +14,9 @@ def serial_init():
         serial_port = serial.Serial(com, baudrate)
         logger.info(f"{com} OPEN.")
     except SerialException:
-        logger.error(f"Cannot open {com}.")
-        sys.exit(-1)
+        logger.error(f"Cannot open {com}")
+        logger.error('Reboot the system.')
+        os.system('systemctl reboot -i')
     return serial_port
 
 


### PR DESCRIPTION
## What does this PR do ? / PRの目的
シリアルポートを開けなかったとき、システムを再起動させる
起動後にシリアルポートが切断したとき、処理が停止する問題を修正

## Implementations / 実装したこと
上の通り

## References / 参考資料
なし