### PR TITLE
nfcリーダーの名前を固定する設定ファイルを追加

### DIFF
--- a/udev-config/98-nfc.rules
+++ b/udev-config/98-nfc.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ACTION=="add", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="06c1", GROUP="plugdev"


### PR DESCRIPTION
## What does this PR do ? / PRの目的
nfcリーダーの名前を固定する設定ファイルを追加

## Implementations / 実装したこと
- udevの固定用ルールを書いた 37a0d07a460598141f653ccb562fa999e1d8fda8

## References / 参考資料
なし